### PR TITLE
Spell-check LanguageMap.md

### DIFF
--- a/doc/LanguageMap.md
+++ b/doc/LanguageMap.md
@@ -5,7 +5,7 @@ The Kusto Query Language was created as part of the Kusto service, also known as
 The contents of this documentation folder are an exact match for the implementation of the language by the Kusto service.
 
 The language has been open-sourced, so that other data platforms and services can benefit and provide their users with a simple and productive language.
-Whether these are are developers, data scientists or data consumers who are familiar with the Kusto Query Language, they can all leverage their language
+Whether these are developers, data scientists or data consumers who are familiar with the Kusto Query Language, they can all leverage their language
 skills across the wide variety of products and services that have adopted it.
 
 To achieve this goal, it is essential that the following conditions will be met:


### PR DESCRIPTION
'are' was continuously used twice by typo so rectified the typo in the documentation.