### PR TITLE
Fix ANTLR grammar to allow naming distinct expressions

### DIFF
--- a/grammar/Kql.g4
+++ b/grammar/Kql.g4
@@ -269,7 +269,7 @@ distinctOperatorStarTarget:
     '*';
 
 distinctOperatorColumnListTarget:
-    Expressions+=unnamedExpression (',' Expressions+=unnamedExpression)*;
+    Expressions+=namedExpression (',' Expressions+=namedExpression)*;
 
 
 evaluateOperator:


### PR DESCRIPTION
This is not documented, but is supported by the Kusto service and is used in the wild.

```kql
StormEvents
| distinct n = strlen(State)
```