### PR TITLE
Fix grammar for summarize group expressions

### DIFF
--- a/grammar/Kql.g4
+++ b/grammar/Kql.g4
@@ -742,7 +742,7 @@ summarizeOperator:
     SUMMARIZE (Parameters+=strictQueryOperatorParameter)* (Expressions+=namedExpression (',' Expressions+=namedExpression)*)? (ByClause=summarizeOperatorByClause)?;
 
 summarizeOperatorByClause:
-    BY Expressions+=namedExpression (',' Expressions+=namedExpression) (BinClause=summarizeOperatorLegacyBinClause)?;
+    BY Expressions+=namedExpression (',' Expressions+=namedExpression)* (BinClause=summarizeOperatorLegacyBinClause)?;
 
 summarizeOperatorLegacyBinClause:
     BIN '=' Expression=numberLikeLiteralExpression;


### PR DESCRIPTION
The grammar previously only allowed exactly two group expressions.