### PR TITLE
Change Enum.GetValues to AOT compatible call

### DIFF
--- a/src/Kusto.Language/Syntax/SyntaxFacts.cs
+++ b/src/Kusto.Language/Syntax/SyntaxFacts.cs
@@ -772,7 +772,11 @@ namespace Kusto.Language.Syntax
             // put in sorted order  TODO: fix list to be in order 
             data.Sort((d1, d2) => string.Compare(d1.Text, d2.Text));
 
+#if NET5_0_OR_GREATER
+            var count = Enum.GetValues<SyntaxKind>().Length;
+#else
             var count = Enum.GetValues(typeof(SyntaxKind)).Length;
+#endif
 
             kindToDataMap = new SyntaxData[count];
             textToKindMap = new TextKeyedDictionary<SyntaxKind>();


### PR DESCRIPTION
Our team wants to use this package to parse KQL but a requirement is that packages must be AOT compatible.  Currently, we get the warning when trying to publish AOT.  This fixes that warning.
```
    D:\git\microsoft\Kusto-Query-Language\src\Kusto.Language\Syntax\SyntaxFacts.cs(775,25): 
    warning IL3050: Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. 
    It might not be possible to create an array of the enum type at runtime. 
    Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.
```
